### PR TITLE
Fix plugin URI

### DIFF
--- a/brevwoo.php
+++ b/brevwoo.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       BrevWoo
- * Plugin URI:        http://github.com/AlecRust/brevwoo
+ * Plugin URI:        https://github.com/AlecRust/brevwoo
  * Description:       Add WooCommerce customers to Brevo the simple way.
  * Version:           1.0.11
  * Author:            Alec Rust


### PR DESCRIPTION
## Summary
- switch to HTTPS for the plugin URI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d78c0c20c8331964691bf93b911b4